### PR TITLE
Fix a panic due to out-of-bounds access of Events

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -426,6 +426,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "io-uring"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b86e202f00093dcba4275d4636b93ef9dd75d025ae560d2521b45ea28ab49013"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "libc",
+]
+
+[[package]]
 name = "itertools"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -842,12 +853,16 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.43.0"
+version = "1.46.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d61fa4ffa3de412bfea335c6ecff681de2b609ba3c77ef3e00e521813a9ed9e"
+checksum = "0cc3a2344dafbe23a245241fe8b09735b521110d30fcefbbd5feb1797ca35d17"
 dependencies = [
  "backtrace",
+ "io-uring",
+ "libc",
+ "mio 1.0.3",
  "pin-project-lite",
+ "slab",
  "tokio-macros",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ ratatui = "0.29"
 futures = "0.3"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-tokio = { version = "1", features = [
+tokio = { version = "1.46", features = [
     "rt-multi-thread",
     "macros",
     "sync",


### PR DESCRIPTION
Due to forgetting to take into account the additional offset from the event pane height, it was possible to overflow the number of events in the list when attempting to display one. This was exacerbated by an issue when PgDown'ing near the bottom of the pane, which erroneously added too much to the self.events_position.

Also put in a fix for https://github.com/advisories/GHSA-rr8g-9fpq-6wmg